### PR TITLE
fix(wheel): don't distribute top-level LICENSE file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ classifiers = [
 ] # https://pypi.org/classifiers/
 description = "Shared functionality for the calcipy-ecosystem"
 documentation = "https://corallium.kyleking.me"
-include = ["LICENSE"]
 keywords = ["calcipy_template"]
 license = "MIT"
 maintainers = []


### PR DESCRIPTION
This file lands in `lib/python3.11/site-packages/LICENSE` which is too generic. The package info folder already has its license there. No need to re-include it.

If not fixed, it collides with the same file provided by i.e. copier-template-tester. See https://github.com/KyleKing/copier-template-tester/pull/33 for that matter.

@moduon MT-1075

<!-- Thanks for contributing!
  To help speed up the code review process, please provide the following information:
  - A short summary of the purpose and links to any relevant GitHub Issues
  - A brief high-level summary of what changed
  - Any additional context or screenshots that would be helpful
-->
